### PR TITLE
chore(next): remove deprecated config and migrate to turbopack

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,34 +1,36 @@
+import { createRequire } from 'module'
+const require = createRequire(import.meta.url)
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Next.js 15.5.0 最適化設定
   experimental: {
     optimizePackageImports: ['recharts', 'lucide-react', '@supabase/supabase-js'],
-    bundlePagesRouterDependencies: true, // Page Router dependency optimization
     optimizeServerReact: true, // Server component optimization
     serverMinification: true, // Server code minification
     serverSourceMaps: false, // Disable source maps in production
-    
+
     // Advanced caching
-    isrMemoryCacheSize: 0, // Use disk cache only
     staleTimes: {
       dynamic: 30, // 30 seconds for dynamic content
       static: 300, // 5 minutes for static content
     },
-    
+
     // Performance optimizations
     webVitalsAttribution: ['CLS', 'LCP', 'FCP', 'TTFB', 'FID'],
-    instrumentationHook: true,
-    
+
     // Bundle optimizations
     optimizeCss: true,
-    turbo: {
-      rules: {
-        '*.svg': {
-          loaders: ['@svgr/webpack'],
-          as: '*.js',
-        },
+  },
+
+  // Next 15.5 turbopack configuration
+  turbopack: {
+    rules: {
+      '*.svg': {
+        loaders: ['@svgr/webpack'],
+        as: '*.js',
       },
-    }
+    },
   },
   
   // React設定
@@ -62,8 +64,6 @@ const nextConfig = {
     disableStaticImages: false,
   },
   
-  // フォント最適化
-  optimizeFonts: true,
   
   // セキュリティヘッダー強化
   async headers() {
@@ -226,9 +226,6 @@ const nextConfig = {
         
         // Minimize configuration
         minimize: true,
-        minimizer: [
-          '...',
-        ],
       }
       
       // Memory leak prevention
@@ -288,7 +285,6 @@ const nextConfig = {
     
     // Advanced production optimizations
     productionBrowserSourceMaps: false,
-    optimizeFonts: true,
     modularizeImports: {
       'lucide-react': {
         transform: 'lucide-react/dist/esm/icons/{{member}}',


### PR DESCRIPTION
## Summary
- remove deprecated Next.js config options and set new turbopack rules
- drop legacy optimizeFonts flag

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run lint` *(fails: no-unused-vars and other lint errors)*
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f03206248333a15f7a3d8ccf9167